### PR TITLE
Make the Callback a C++ Function

### DIFF
--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -264,7 +264,7 @@ SolNum Sampler::bounded_sol_count(
 
             for (uint32_t i = 0; i < sols_to_return(solutions); i++) {
                 const auto& model = models.at(modelIndices.at(i));
-                (*callback_func)(get_solution_ints(model), callback_func_data);
+                callback_func(get_solution_ints(model), callback_func_data);
             }
         }
     }
@@ -426,7 +426,7 @@ void Sampler::generate_samples(const uint32_t num_samples_needed)
                 ++it;
             }
             samples++;
-            (*callback_func)(*it, callback_func_data);
+            callback_func(*it, callback_func_data);
         }
     }
 

--- a/src/unigen.h.in
+++ b/src/unigen.h.in
@@ -33,6 +33,7 @@
 #include <string>
 #include <vector>
 #include <fstream>
+#include <functional>
 #include <cryptominisat5/cryptominisat.h>
 #include <cryptominisat5/solvertypesmini.h>
 
@@ -43,7 +44,7 @@ namespace ApproxMC {
 
 namespace UniGen {
 
-typedef void (*callback)(const std::vector<int>& solution, void* data);
+typedef std::function<void(const std::vector<int>& solution, void* data)> callback;
 
 struct UniGenPrivateData;
 #ifdef _WIN32


### PR DESCRIPTION
This is a more modern option which includes the original use case plus
other features like passing a lambda as a callback, using member
methods, etc.